### PR TITLE
copycat: Change magic-static to magic

### DIFF
--- a/tools/copycat/Makefile
+++ b/tools/copycat/Makefile
@@ -92,7 +92,7 @@ COPYCAT_LIB = \
 	-stk-version \
 	-sncbi-vdb \
 	-skff \
-	-smagic-static
+	-smagic
 
 
 $(BINDIR)/copycat: $(COPYCAT_OBJ)


### PR DESCRIPTION
Fix the error:
```
ld: library not found for -lmagic-static
```

The file `libmagic-static.*` does not exist on Ubuntu.
See https://packages.ubuntu.com/search?searchon=contents&keywords=libmagic-static&mode=filename&suite=xenial&arch=amd64

There is however a file name `libmagic.so`.
See https://packages.ubuntu.com/search?mode=filename&suite=xenial&section=all&arch=amd64&keywords=libmagic.so&searchon=contents

See the failed build log at
https://gist.githubusercontent.com/sjackman/1d82c11853fd4c16bbfa7d0e3f553e2b/raw/543e2b51e6db0eeef42208198a860664892d2d02/08.make
and https://gist.github.com/sjackman/1d82c11853fd4c16bbfa7d0e3f553e2b#file-08-make-cc