### PR TITLE
Fix bioconda build

### DIFF
--- a/tools/driver-tool/utf8proc/Makefile
+++ b/tools/driver-tool/utf8proc/Makefile
@@ -75,7 +75,7 @@ utf8proc.o: utf8proc.h utf8proc.c utf8proc_data.c
 
 libutf8proc.a: utf8proc.o
 	rm -f libutf8proc.a
-	$(AR) rs libutf8proc.a utf8proc.o
+	$(AR) libutf8proc.a utf8proc.o
 
 libutf8proc.so.$(MAJOR).$(MINOR).$(PATCH): utf8proc.o
 	$(CC) $(LDFLAGS) -shared -o $@ -Wl,-soname -Wl,libutf8proc.so.$(MAJOR) utf8proc.o


### PR DESCRIPTION
This might not be the right fix, but without this the bioconda
build fails with:
```
09:47:55 BIOCONDA INFO (OUT) make[6]: Entering directory `$SRC_DIR/sra-tools/tools/driver-tool/utf8proc'
09:47:55 BIOCONDA INFO (OUT) gcc -c  -std=gnu11  -DNDEBUG -m64   -DLINUX -DUNIX -D_GNU_SOURCE -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DPKGNAME=linux64 -D_ARCH_BITS=__SIZEOF_POINTER__*__CHAR_BIT__ -DLIBPREFIX=lib -DSHLIBEXT=so  -I$SRC_DIR/sra-tools/interfaces/override -I$SRC_DIR/sra-tools/tools/driver-tool/json/linux -I$SRC_DIR/sra-tools/tools/driver-tool/json/unix -I$SRC_DIR/sra-tools/tools/driver-tool/json -I$SRC_DIR/ncbi-vdb/interfaces/ -I$SRC_DIR/ncbi-vdb/interfaces/cc/gcc/x86_64 -I$SRC_DIR/ncbi-vdb/interfaces/cc/gcc -I$SRC_DIR/ncbi-vdb/interfaces/os/linux -I$SRC_DIR/ncbi-vdb/interfaces/os/unix -I$SRC_DIR/ncbi-vdb/interfaces/ext -I$PREFIX/include -I. -MD -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem $PREFIX/include -std=gnu11 -DNDEBUG -m64 -DLINUX -DUNIX -D_GNU_SOURCE -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DPKGNAME=linux64 -D_ARCH_BITS=__SIZEOF_POINTER__*__CHAR_BIT__ -DLIBPREFIX=lib -DSHLIBEXT=so -I$SRC_DIR/sra-tools/interfaces/override -I$SRC_DIR/sra-tools/tools/driver-tool/json/linux -I$SRC_DIR/sra-tools/tools/driver-tool/json/unix -I$SRC_DIR/sra-tools/tools/driver-tool/json -I$SRC_DIR/ncbi-vdb/interfaces/ -I$SRC_DIR/ncbi-vdb/interfaces/cc/gcc/x86_64 -I$SRC_DIR/ncbi-vdb/interfaces/cc/gcc -I$SRC_DIR/ncbi-vdb/interfaces/os/linux -I$SRC_DIR/ncbi-vdb/interfaces/os/unix -I$SRC_DIR/ncbi-vdb/interfaces/ext -I$PREFIX/include -I. -fPIC -std=c99 -Wall -pedantic -DUTF8PROC_EXPORTS -c -o utf8proc.o utf8proc.c
09:47:56 BIOCONDA INFO (OUT) rm -f libutf8proc.a
09:47:56 BIOCONDA INFO (OUT) ar rc rs libutf8proc.a utf8proc.o
09:47:56 BIOCONDA INFO (OUT) ar: libutf8proc.a: No such file or directory
09:47:56 BIOCONDA INFO (OUT) make[6]: *** [libutf8proc.a] Error 1
09:47:56 BIOCONDA INFO (OUT) make[6]: Leaving directory `$SRC_DIR/sra-tools/tools/driver-tool/utf8proc'
09:47:56 BIOCONDA INFO (OUT) make[5]: *** [/opt/conda/conda-bld/sra-tools_1582710149751/work/sra-tools/tools/driver-tool/utf8proc/utf8proc.o] Error 2
09:47:56 BIOCONDA INFO (OUT) make[5]: Leaving directory `$SRC_DIR/ncbi-outdir/sra-tools/linux/gcc/x86_64/rel/obj/tools/driver-tool/json'
09:47:56 BIOCONDA INFO (OUT) make[4]: *** [std] Error 2
09:47:56 BIOCONDA INFO (OUT) make[4]: Leaving directory `$SRC_DIR/sra-tools/tools/driver-tool/json'
09:47:56 BIOCONDA INFO (OUT) make[3]: *** [/opt/conda/conda-bld/sra-tools_1582710149751/work/ncbi-outdir/sra-tools/linux/gcc/x86_64/rel/ilib/libjson.a] Error 2
09:47:56 BIOCONDA INFO (OUT) make[3]: Leaving directory `$SRC_DIR/ncbi-outdir/sra-tools/linux/gcc/x86_64/rel/obj/tools/driver-tool'
09:47:56 BIOCONDA INFO (OUT) make[2]: *** [std] Error 2
09:47:56 BIOCONDA INFO (OUT) make[2]: Leaving directory `$SRC_DIR/sra-tools/tools/driver-tool'
09:47:56 BIOCONDA INFO (OUT) make[1]: *** [driver-tool] Error 2
09:47:56 BIOCONDA INFO (OUT) make[1]: Leaving directory `$SRC_DIR/sra-tools/tools'
09:47:56 BIOCONDA INFO (OUT) make: *** [tools] Error 2
```