### PR TITLE
Clarify fasterq-dump options containing units

### DIFF
--- a/tools/driver-tool/imp_fasterq_dump.cpp
+++ b/tools/driver-tool/imp_fasterq_dump.cpp
@@ -92,11 +92,14 @@ struct FasterqParams final : CmnOptAndAccessions
         cmdline . addOption ( outdir, nullptr, "O", "outdir", "<path>",
             "path for outputfile (overrides usage of current directory, but uses given accession)" );
         cmdline . addOption ( bufsize, nullptr, "b", "bufsize", "<size>",
-            "size of file-buffer (dflt=1MB, takes number or number and unit)" );
+            "size of file-buffer (dflt=1MB, takes number or number and unit "
+            "where unit is one of (K|M|G) case-insensitive)");
         cmdline . addOption ( curcache, nullptr, "c", "curcache", "<size>",
-            "size of cursor-cache (dflt=10MB, takes number or number and unit)" );
+            "size of cursor-cache (dflt=10MB, takes number or number unit "
+            "where unit is one of (K|M|G) case-insensitive)");
         cmdline . addOption ( mem, nullptr, "m", "mem", "<size>",
-            "memory limit for sorting (dflt=100MB, takes number or number and unit)" );
+            "memory limit for sorting (dflt=100MB, takes number or number and unit "
+            "where unit is one of (K|M|G) case-insensitive)");
         cmdline . addOption ( temp, nullptr, "t", "temp", "<path>",
             "path to directory for temp. files (dflt=current dir.)" );
 


### PR DESCRIPTION
This PR clarifies that the "unit" in the `fasterq-dump` options `--bufsize`, `--curcache` and `--mem` can be a single, case-insensitive character K, M, or G according `get_size_t_option`:

https://github.com/ncbi/sra-tools/blob/1307a46c0337359e2fea385ccb536a34c06dd3c7/tools/fasterq-dump/helper.c#L124-L129

The help option descriptions currently use "MB" in stating defaults e.g. for  `--mem`: `memory limit for sorting (dflt=100MB`, yet "MB" does not work as a unit:

```bash
$ fasterq-dump -V
"fasterq-dump" version 2.10.7

# MB does not work as a unit (reads as '4000000000' bytes):
$ fasterq-dump -x -m 4000000000MB SRR000001
mem-limit    : 4,000,000,000 bytes

# M does work:
$ fasterq-dump -x -m 4000M SRR000001
mem-limit    : 4,194,304,000 bytes