### PR TITLE
Improve "TOOL_NAME was not found" error message

### DIFF
--- a/tools/driver-tool/imp_fastq_dump.cpp
+++ b/tools/driver-tool/imp_fastq_dump.cpp
@@ -363,12 +363,11 @@ struct FastqParams final : CmnOptAndAccessions
 
     int run() const override {
         auto const theirArgv0 = what.toolpath.getPathFor(TOOL_NAME).fullpath();
-        {
-            auto const realpath = what.toolpath.getPathFor(TOOL_ORIGINAL_NAME);
-            if (realpath.executable())
-                return ToolExec::run(TOOL_NAME, realpath.fullpath(), theirArgv0, *this, accessions);
-        }
-        throw std::runtime_error(TOOL_NAME " was not found or is not executable.");
+        auto const realpath = what.toolpath.getPathFor(TOOL_ORIGINAL_NAME);
+        if (realpath.executable())
+            return ToolExec::run(TOOL_NAME, realpath.fullpath(), theirArgv0, *this, accessions);
+
+        throw std::runtime_error(realpath.fullpath() + " (aka " TOOL_NAME ") was not found or is not executable.");
     }
 
 };

--- a/tools/driver-tool/support2.cpp
+++ b/tools/driver-tool/support2.cpp
@@ -451,9 +451,6 @@ namespace sratools2
             std::cerr << e.what() << std::endl;
             return EX_USAGE;
         }
-        catch (std::exception const &e) {
-            throw e;
-        }
         catch (...) {
             throw;
         }


### PR DESCRIPTION
It is true that #497, #530, and #555 are issues currently limited to the bioconda build of sra-tools on macOS and can be addressed within bioconda. However the error message is uninformative due to minor issues in the sra-tools source code:

```
$ fastq-dump
An error occured: std::exception
If this continues to happen, please contact the SRA Toolkit at […]
```

`e.what()` just prints `std::exception` because the exception object has been sliced when it was rethrown, and it is now a new `std::exception` object rather than the `std::runtime_error` object originally thrown. This is fixed by the patch to _support2.cpp_ in this PR.

With that fixed, the error give you a hint what is going on:

```
$ fastq-dump
An error occured: fastq-dump was not found or is not executable.
If this continues to happen, please contact the SRA Toolkit at […]
```

However the message is still not terribly useful for debugging the situation, as it gives no clue where it was looking for the executable. The patch to _imp_fastq_dump.cpp_ adds the path that the code is checking for to the error message. There is similar code in the other _imp\_\*.cpp_ files' `run()` routines that could benefit from a similar change.