### PR TITLE
VDB-4696

### DIFF
--- a/tools/bam-loader/loader-imp.c
+++ b/tools/bam-loader/loader-imp.c
@@ -857,7 +857,10 @@ static rc_t VerifyReferences(BAM_File const *bam, Reference const *ref)
 
         rc = ReferenceVerify(ref, refSeq->name, refSeq->length, refSeq->checksum);
         if (rc) {
-            if (GetRCObject(rc) == rcChecksum && GetRCState(rc) == rcUnequal) {
+            if (GetRCObject(rc) == rcId && GetRCState(rc) == rcUndefined) {
+                (void)PLOGMSG(klogInfo, (klogInfo, "Reference: '$(name)' is unmapped", "name=%s", refSeq->name));
+            }
+            else if (GetRCObject(rc) == rcChecksum && GetRCState(rc) == rcUnequal) {
 #if NCBI
                 (void)PLOGMSG(klogWarn, (klogWarn, "Reference: '$(name)', Length: $(len); checksums do not match", "name=%s,len=%u", refSeq->name, (unsigned)refSeq->length));
 #endif


### PR DESCRIPTION
Changed reference validation messages to not complain about references that are marked as *UNMAPPED in config.

