### PR TITLE
Update ngs-java `CMakeLists.txt` file

### DIFF
--- a/ngs/ngs-java/CMakeLists.txt
+++ b/ngs/ngs-java/CMakeLists.txt
@@ -133,7 +133,7 @@ if ( Java_FOUND )
                 ngs-doc-jar ALL COMMAND
                 bash -c "${Java_JAR_EXECUTABLE} -cfv ${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar ."
                 DEPENDS ngs-doc_javadoc
-                WORKING_DIRECTORY "${TARGDIR}/obj/ngs/ngs-java/javadoc/ngs-doc"
+                WORKING_DIRECTORY "${TARGDIR}/ngs/ngs-java/javadoc/ngs-doc"
             )
             install( FILES ${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar DESTINATION ${CMAKE_INSTALL_PREFIX}/jar/ )
 


### PR DESCRIPTION
Hello,

It appears that the `WORKING_DIRECTORY` value for `ngs-doc` needs to be updated. I hit a build error when attempting to install v3.0.0, and removing `obj/` appears to have resolve the issue.

For reference, here's my [current CMake build script for sra-tools](https://github.com/acidgenomics/koopa/blob/develop/lang/shell/bash/include/installers/common/shared/install-sra-tools.sh).

Best,
Mike