### PR TITLE
.pbi file format doesn't need unpacking

### DIFF
--- a/tools/copycat/ccfileformat.c
+++ b/tools/copycat/ccfileformat.c
@@ -105,6 +105,7 @@ static const char exttable [] =
     "tar\tTapeArchive\n"
     "xml\tExtensibleMarkupLanguage\n"
     "h5\tHD5\n"
+    "pbi\tPacBioBAMIndex\n"
 };
 
 static const char classtable [] = 
@@ -127,6 +128,7 @@ static const char formattable [] =
     "StandardFlowgramFormat\tRead\n"
     "TapeArchive\tArchive\n"
     "HD5\tArchive\n"
+    "PacBioBAMIndex\tRead\n"
 };
 
 static const char magicpath [] = "/usr/share/misc/magic";
@@ -306,9 +308,17 @@ rc_t CCFileFormatGetType (const CCFileFormat * self, const KFile * file,
                                      (klogWarn, "File '$(path)' is in unzupported winzip/pkzip format",
                                       "path=%s", path));
                         }
-                        else if (!strcmp("BinaryAlignmentMap", etypebuf) && !strcmp ("GnuZip", mtypebuf))
+                        else if (strcmp("BinaryAlignmentMap", etypebuf) == 0 && strcmp ("GnuZip", mtypebuf) == 0)
                         {
                             /* bam files have gnuzip magic, we need to treat them as data files ***/
+                            strcpy (mclassbuf, eclassbuf );
+                            strcpy (mtypebuf, etypebuf);
+                            mtype = etype;
+                            mclass = eclass;
+                        }
+                        else if (strcmp("PacBioBAMIndex", etypebuf) == 0 && strcmp("GnuZip", mtypebuf) == 0)
+                        {
+                            /* pbi files have gnuzip magic, we need to treat them as data files ***/
                             strcpy (mclassbuf, eclassbuf );
                             strcpy (mtypebuf, etypebuf);
                             mtype = etype;


### PR DESCRIPTION
VDB-4982: Fix for the incorrect behavior of copycat with .bam.pbi files. Those are PacBio BAM index files and do not need unpacking/analyzing despite being identified as gzip compressed.