### PR TITLE
Fixes for the SRA-2499 and SRA-11821. Resolves issues with XML files

### DIFF
--- a/tools/copycat/ccfileformat.c
+++ b/tools/copycat/ccfileformat.c
@@ -87,10 +87,12 @@ static const char magictable [] =
     "Standard Flowgram Format (SFF)\tStandardFlowgramFormat\n"
     "NCBI kar sequence read archive\tSequenceReadArchive\n"
     "tar archive\tTapeArchive\n"
-    "XML document text\tExtensibleMarkupLanguage\n"
+    "XML document\tExtensibleMarkupLanguage\n"
+    "XML 1.0 document\tExtensibleMarkupLanguage\n"
     "bzip2 compressed data\tBzip\n"
     "Zip archive data\tWinZip\n"
     "gzip compressed data\tGnuZip\n"
+    "Hierarchical Data Format (version 5) data\tHD5\n"
 };
 static const char exttable [] =
 {
@@ -127,7 +129,7 @@ static const char formattable [] =
     "SequenceReadArchive\tArchive\n"
     "StandardFlowgramFormat\tRead\n"
     "TapeArchive\tArchive\n"
-    "HD5\tArchive\n"
+    "HD5\tRead\n"
     "PacBioBAMIndex\tRead\n"
 };
 


### PR DESCRIPTION
Fixes for the SRA-2499 and SRA-11821. Resolves multiple issues with XML files recognition via magic table, failure to extract HDF5 files from tar archives. Also adds HDF5 detection based on libmagic, not just .h5 extension.