### PR TITLE
SEA-11967: copycat bam support

### DIFF
--- a/tools/internal/copycat/ccfileformat.c
+++ b/tools/internal/copycat/ccfileformat.c
@@ -93,6 +93,7 @@ static const char magictable [] =
     "Zip archive data\tWinZip\n"
     "gzip compressed data\tGnuZip\n"
     "Hierarchical Data Format (version 5) data\tHD5\n"
+    "Binary Alignment Map\tBinaryAlignmentMap\n"
 };
 static const char exttable [] =
 {


### PR DESCRIPTION
Added support for BAM format recognition based on magic file, not extension only.