### PR TITLE
Win32 fixes

### DIFF
--- a/test/external/driver-tool/test-sdl-response.cpp
+++ b/test/external/driver-tool/test-sdl-response.cpp
@@ -38,6 +38,29 @@
 #include "json-parse.cpp"
 #include "SDL-response.cpp"
 
+#define IGNORE(X) do { (void)(X); } while (0)
+
+struct test_failure: public std::exception
+{
+    char const *test_name;
+    test_failure(char const *test) : test_name(test) {}
+    char const *what() const throw() { return test_name; }
+};
+
+struct assertion_failure: public std::exception
+{
+    std::string message;
+    assertion_failure(char const *expr, char const *function, int line)
+    {
+        message = std::string(__FILE__) + ":" + std::to_string(line) + " in function " + function + " assertion failed: " + expr;
+    }
+    char const *what() const throw() { return message.c_str(); }
+};
+
+#define S_(X) #X
+#define S(X) S_(X)
+#define ASSERT(X) do { if (X) break; throw assertion_failure(#X, __FUNCTION__, __LINE__); } while (0)
+
 template <typename IMPL, typename RESPONSE = typename IMPL::Base, typename DELEGATE = typename IMPL::Delegate>
 static RESPONSE makeFrom(char const *json)
 {
@@ -83,7 +106,7 @@ struct Response2Tests {
                                 "payRequired": true
                             }
                             )###");
-                        assert(obj.payRequired == true);
+                        ASSERT(obj.payRequired == true);
                         LOG(9) << __FUNCTION__ << " successful" << std::endl;
                         return;
                     }
@@ -96,10 +119,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void havePayRTestFalse() {
                     try {
@@ -123,10 +143,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void badCER() {
                     try {
@@ -138,7 +155,7 @@ struct Response2Tests {
                                 "ceRequired": "foo"
                             }
                             )###");
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (JSONScalarConversionError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got JSONScalarConversionError" << std::endl;
@@ -154,7 +171,7 @@ struct Response2Tests {
                                 "ceRequired": null
                             }
                             )###");
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (JSONScalarConversionError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got JSONScalarConversionError" << std::endl;
@@ -170,7 +187,7 @@ struct Response2Tests {
                                 "ceRequired": true
                             }
                             )###");
-                        assert(obj.ceRequired == true);
+                        ASSERT(obj.ceRequired == true);
                         LOG(9) << __FUNCTION__ << " successful" << std::endl;
                         return;
                     }
@@ -183,10 +200,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void haveCERTestFalse() {
                     try {
@@ -210,10 +224,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void haveProjectTest() {
                     try {
@@ -225,7 +236,7 @@ struct Response2Tests {
                                 "encryptedForProjectId": "phs-1234"
                             }
                             )###");
-                        assert(obj.projectId && obj.projectId.value() == "phs-1234");
+                        ASSERT(obj.projectId && obj.projectId.value() == "phs-1234");
                         LOG(9) << __FUNCTION__ << " successful" << std::endl;
                         return;
                     }
@@ -238,10 +249,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void haveExpDateTest() {
                     try {
@@ -253,7 +261,7 @@ struct Response2Tests {
                                 "expirationDate": "2012-01-19T20:14:00Z"
                             }
                             )###");
-                        assert(obj.expirationDate && obj.expirationDate.value() == "2012-01-19T20:14:00Z");
+                        ASSERT(obj.expirationDate && obj.expirationDate.value() == "2012-01-19T20:14:00Z");
                         LOG(9) << __FUNCTION__ << " successful" << std::endl;
                         return;
                     }
@@ -266,10 +274,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void defaultedRegionTest() {
                     try {
@@ -279,7 +284,7 @@ struct Response2Tests {
                                 "link": "https://foo.bar.baz"
                             }
                             )###");
-                        assert(obj.region == "be-md");
+                        ASSERT(obj.region == "be-md");
                         LOG(9) << __FUNCTION__ << " successful" << std::endl;
                         return;
                     }
@@ -292,10 +297,7 @@ struct Response2Tests {
                     catch (Response2::DecodingError const &e) {
                         std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                     }
-                    catch (...) {
-                        std::cerr << __FUNCTION__ << " failed" << std::endl;
-                    }
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 void missingRegionTest() {
                     try {
@@ -305,7 +307,7 @@ struct Response2Tests {
                                 "link": "https://foo.bar.baz"
                             }
                             )###");
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (Response2::DecodingError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -316,7 +318,7 @@ struct Response2Tests {
                         makeFrom(
                             R"###( { "service": "sra-ncbi" } )###"
                         );
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (Response2::DecodingError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -325,7 +327,7 @@ struct Response2Tests {
                 void missingServiceTest() {
                     try {
                         makeFrom(R"###( { "link": "https" } )###");
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (Response2::DecodingError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -334,7 +336,7 @@ struct Response2Tests {
                 void emptyObjectTest() {
                     try {
                         makeFrom("{}");
-                        throw __FUNCTION__;
+                        throw test_failure(__FUNCTION__);
                     }
                     catch (Response2::DecodingError const &e) {
                         LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -369,7 +371,7 @@ struct Response2Tests {
                             "format": "text/fasta"
                         }
                         )###");
-                    assert(obj.format && obj.format.value() == "text/fasta");
+                    ASSERT(obj.format && obj.format.value() == "text/fasta");
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -382,10 +384,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void haveNoQualTest() {
                 try {
@@ -397,7 +396,7 @@ struct Response2Tests {
                             "noqual": true
                         }
                         )###");
-                    assert(obj.noqual == true);
+                    ASSERT(obj.noqual == true);
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -410,10 +409,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void haveModDateTest() {
                 try {
@@ -425,7 +421,7 @@ struct Response2Tests {
                             "modificationDate": "2016-11-20T07:38:19Z"
                         }
                         )###");
-                    assert(obj.modificationDate && obj.modificationDate.value() == "2016-11-20T07:38:19Z");
+                    ASSERT(obj.modificationDate && obj.modificationDate.value() == "2016-11-20T07:38:19Z");
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -438,10 +434,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void haveMD5Test() {
                 try {
@@ -453,7 +446,7 @@ struct Response2Tests {
                             "md5": "323d0b76f741ae0b71aeec0176645301"
                         }
                         )###");
-                    assert(obj.md5 && obj.md5.value() == "323d0b76f741ae0b71aeec0176645301");
+                    ASSERT(obj.md5 && obj.md5.value() == "323d0b76f741ae0b71aeec0176645301");
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -466,10 +459,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void haveSizeTest() {
                 try {
@@ -481,7 +471,7 @@ struct Response2Tests {
                             "size": 842809
                         }
                         )###");
-                    assert(obj.size && obj.size.value() == "842809");
+                    ASSERT(obj.size && obj.size.value() == "842809");
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -494,10 +484,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void defaultedTypeTest() {
                 try {
@@ -507,7 +494,7 @@ struct Response2Tests {
                             "name": "AAAA02.11"
                         }
                         )###");
-                    assert(obj.type == "sra");
+                    ASSERT(obj.type == "sra");
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -520,10 +507,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void emptyLocationsTest() {
                 try {
@@ -534,7 +518,7 @@ struct Response2Tests {
                             "locations": []
                         }
                         )###");
-                    assert(obj.locations.empty());
+                    ASSERT(obj.locations.empty());
                     LOG(9) << __FUNCTION__ << " successful" << std::endl;
                     return;
                 }
@@ -547,10 +531,7 @@ struct Response2Tests {
                 catch (Response2::DecodingError const &e) {
                     std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
                 }
-                catch (...) {
-                    std::cerr << __FUNCTION__ << " failed" << std::endl;
-                }
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             void noDefaultTypeTest() {
                 try {
@@ -558,7 +539,7 @@ struct Response2Tests {
                         "name": "SRR000002",
                         "object": "srapub|SRR000002"
                     } )###");
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 catch (Response2::DecodingError const &e) {
                     LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -567,7 +548,7 @@ struct Response2Tests {
             void missingTypeTest() {
                 try {
                     makeFrom(R"###( { "name": "SRR000002" } )###");
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 catch (Response2::DecodingError const &e) {
                     LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -576,7 +557,7 @@ struct Response2Tests {
             void missingNameTest() {
                 try {
                     makeFrom(R"###( { "type": "sra" } )###");
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 catch (Response2::DecodingError const &e) {
                     LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -585,7 +566,7 @@ struct Response2Tests {
             void emptyObjectTest() {
                 try {
                     makeFrom("{}");
-                    throw __FUNCTION__;
+                    throw test_failure(__FUNCTION__);
                 }
                 catch (Response2::DecodingError const &e) {
                     LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -613,9 +594,9 @@ struct Response2Tests {
                         "msg": "No data at given location.region"
                     }
                     )###");
-                assert(obj.query == "SRR867664");
-                assert(obj.status == "404");
-                assert(obj.message == "No data at given location.region");
+                ASSERT(obj.query == "SRR867664");
+                ASSERT(obj.status == "404");
+                ASSERT(obj.message == "No data at given location.region");
                 LOG(9) << __FUNCTION__ << " successful" << std::endl;
                 return;
             }
@@ -628,10 +609,7 @@ struct Response2Tests {
             catch (Response2::DecodingError const &e) {
                 std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
             }
-            catch (...) {
-                std::cerr << __FUNCTION__ << " failed" << std::endl;
-            }
-            throw __FUNCTION__;
+            throw test_failure(__FUNCTION__);
         }
         void missingMessageTest() {
             try {
@@ -641,7 +619,7 @@ struct Response2Tests {
                         "bundle": "foo"
                     }
                 )###");
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             catch (Response2::DecodingError const &e) {
                 LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -655,7 +633,7 @@ struct Response2Tests {
                         "msg": "Hello World"
                     }
                 )###");
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             catch (Response2::DecodingError const &e) {
                 LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -669,7 +647,7 @@ struct Response2Tests {
                         "bundle": "foo"
                     }
                 )###");
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             catch (Response2::DecodingError const &e) {
                 LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -678,7 +656,7 @@ struct Response2Tests {
         void emptyObjectTest() {
             try {
                 makeFrom("{}");
-                throw __FUNCTION__;
+                throw test_failure(__FUNCTION__);
             }
             catch (Response2::DecodingError const &e) {
                 LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -702,13 +680,13 @@ struct Response2Tests {
         }
         catch (char const *function) {
             std::cerr << function << " failed." << std::endl;
+            throw test_failure(function);
         }
-        abort();
     }
     static void testEmpty2() {
         try {
             Response2::makeFrom("{}");
-            throw __FUNCTION__;
+            throw test_failure(__FUNCTION__);
         }
         catch (Response2::DecodingError const &e) {
             LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
@@ -718,7 +696,7 @@ struct Response2Tests {
         // version is supposed to be a string value.
         try {
             Response2::makeFrom(R"###({ "version": 99 })###");
-            throw __FUNCTION__;
+            throw test_failure(__FUNCTION__);
         }
         catch (JSONScalarConversionError const &e) {
             LOG(9) << __FUNCTION__ << " successful, got: JSONScalarConversionError" << std::endl;
@@ -728,11 +706,11 @@ struct Response2Tests {
         // version is supposed to "2" or "2.x".
         try {
             Response2::makeFrom(R"###({ "version": "99" })###");
-            throw __FUNCTION__;
+            throw test_failure(__FUNCTION__);
         }
         catch (Response2::DecodingError const &e) {
-            assert(e.object == Response2::DecodingError::topLevel);
-            assert(e.haveCause("version"));
+            ASSERT(e.object == Response2::DecodingError::topLevel);
+            ASSERT(e.haveCause("version"));
             LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
         }
     }
@@ -751,10 +729,7 @@ struct Response2Tests {
         catch (Response2::DecodingError const &e) {
             std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
         }
-        catch (...) {
-            std::cerr << __FUNCTION__ << " failed" << std::endl;
-        }
-        throw __FUNCTION__;
+        throw test_failure(__FUNCTION__);
     }
     static void testBadResult() {
         try {
@@ -763,10 +738,10 @@ struct Response2Tests {
                     "version": "2",
                     "result": [{}]
                 })###");
-            throw __FUNCTION__;
+            throw test_failure(__FUNCTION__);
         }
         catch (Response2::DecodingError const &e) {
-            assert(e.object == Response2::DecodingError::result);
+            ASSERT(e.object == Response2::DecodingError::result);
             LOG(9) << __FUNCTION__ << " successful, got: " << e << std::endl;
         }
     }
@@ -778,8 +753,9 @@ struct Response2Tests {
                     "status": 500,
                     "message": "Internal Server Error"
                 })###");
-            assert(response.status == "500" && response.message == "Internal Server Error");
+            ASSERT(response.status == "500" && response.message == "Internal Server Error");
             LOG(9) << __FUNCTION__ << " successful" << std::endl;
+            return;
         }
         catch (JSONParser::Error const &e) {
             std::cerr << __FUNCTION__ << " failed, got: JSONParser::Error" << std::endl;
@@ -790,9 +766,7 @@ struct Response2Tests {
         catch (Response2::DecodingError const &e) {
             std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
         }
-        catch (...) {
-            std::cerr << __FUNCTION__ << " failed" << std::endl;
-        }
+        throw test_failure(__FUNCTION__);
     }
     static void testGoodResponse() {
         try {
@@ -808,6 +782,7 @@ struct Response2Tests {
                     ]
                 })###");
             LOG(9) << __FUNCTION__ << " successful" << std::endl;
+            return;
         }
         catch (JSONParser::Error const &e) {
             std::cerr << __FUNCTION__ << " failed, got: JSONParser::Error" << std::endl;
@@ -818,9 +793,7 @@ struct Response2Tests {
         catch (Response2::DecodingError const &e) {
             std::cerr << __FUNCTION__ << " failed, got: " << e << std::endl;
         }
-        catch (...) {
-            std::cerr << __FUNCTION__ << " failed" << std::endl;
-        }
+        throw test_failure(__FUNCTION__);
     }
 };
 
@@ -829,7 +802,7 @@ static void Response2_test_vdbcache() {
 
     auto const testJSON = R"###(
 {
-    "version": "unstable",
+    "version": "2",
     "result": [
         {
             "bundle": "SRR850901",
@@ -901,38 +874,44 @@ static void Response2_test_vdbcache() {
     ]
 }
 )###";
-    auto const &raw = Response2::makeFrom(testJSON);
+    try {
+        auto const &raw = Response2::makeFrom(testJSON);
 
-    assert(raw.results.size() == 1);
-    auto passed = false;
-    auto const files = raw.results[0].files.size();
-    auto sras = 0;
-    auto srrs = 0;
+        ASSERT(raw.results.size() == 1);
+        auto passed = false;
+        auto const files = raw.results[0].files.size();
+        auto sras = 0;
+        auto srrs = 0;
 
-    for (auto const &fl : raw.results[0].getByType("sra")) {
-        auto const &file = fl.first;
+        for (auto const &fl : raw.results[0].getByType("sra")) {
+            auto const &file = fl.first;
 
-        assert(file.type == "sra");
-        ++sras;
+            ASSERT(file.type == "sra");
+            ++sras;
 
-        if (file.hasExtension(".pileup")) continue;
-        ++srrs;
+            if (file.hasExtension(".pileup")) continue;
+            ++srrs;
 
-        auto const vcache = raw.results[0].getCacheFor(fl);
-        assert(vcache >= 0);
+            auto const vcache = raw.results[0].getCacheFor(fl);
+            ASSERT(vcache >= 0);
 
-        auto const &vdbcache = raw.results[0].flat(vcache).second;
-        assert(vdbcache.service == "sra-ncbi");
-        assert(vdbcache.region == "public");
+            auto const &vdbcache = raw.results[0].flat(vcache).second;
+            ASSERT(vdbcache.service == "sra-ncbi");
+            ASSERT(vdbcache.region == "public");
 
-        passed = true;
+            passed = true;
+        }
+        ASSERT(files == 4);
+        ASSERT(sras == 2);
+        ASSERT(srrs == 1);
+        ASSERT(passed);
+
+        LOG(8) << "vdbcache location matching passed." << std::endl;
     }
-    assert(files == 4);
-    assert(sras == 2);
-    assert(srrs == 1);
-    assert(passed);
-
-    LOG(8) << "vdbcache location matching passed." << std::endl;
+    catch (Response2::DecodingError const &e) {
+        std::cerr << e << std::endl;
+        throw test_failure(__FUNCTION__);
+    }
 }
 
 #if WINDOWS
@@ -943,10 +922,13 @@ int main ( int argc, char *argv[], char *envp[])
 {
     try {
         Response2_test_vdbcache();
+        return 0;
+    }
+    catch (test_failure const &e) {
+        std::cerr << "test " << e.what() << " failed." << std::endl;
     }
     catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
-        return 3;
     }
-    return 0;
+    return 3;
 }

--- a/test/external/driver-tool/test-uuid.cpp
+++ b/test/external/driver-tool/test-uuid.cpp
@@ -40,6 +40,29 @@
 #include <cassert>
 #include "uuid.cpp"
 
+#define IGNORE(X) do { (void)(X); } while (0)
+
+struct test_failure: public std::exception
+{
+    char const *test_name;
+    test_failure(char const *test) : test_name(test) {}
+    char const *what() const throw() { return test_name; }
+};
+
+struct assertion_failure: public std::exception
+{
+    std::string message;
+    assertion_failure(char const *expr, char const *function, int line)
+    {
+        message = std::string(__FILE__) + ":" + std::to_string(line) + " in function " + function + " assertion failed: " + expr;
+    }
+    char const *what() const throw() { return message.c_str(); }
+};
+
+#define S_(X) #X
+#define S(X) S_(X)
+#define ASSERT(X) do { if (X) break; throw assertion_failure(#X, __FUNCTION__, __LINE__); } while (0)
+
 static bool uuid_is_valid(std::string const &buffer)
 {
     if (buffer.size() != 36) return false;
@@ -81,35 +104,35 @@ static bool uuid_is_valid(std::string const &buffer)
 
 void uuid_test(void)
 {
-    assert(uuid_is_valid("a38fa5da-1456-498a-8ef5-1f39e35bfe57"));
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35bfe57"));
-    assert(uuid_is_valid("a38fa5da-1456-498a-aef5-1f39e35bfe57"));
-    assert(uuid_is_valid("a38fa5da-1456-498a-bef5-1f39e35bfe57"));
-    assert(uuid_is_valid("a38fa5da-1456-098a-9ef5-1f39e35bfe57") == false); // invalid type
-    assert(uuid_is_valid("a38fa5da-1456-498a-0ef5-1f39e35bfe57") == false); // invalid subtype
-    assert(uuid_is_valid("a38fa5da11456-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-14562498a-9ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-498a39ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef541f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38f-5da-1456-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-14-6-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-49-a-9ef5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-498a-9e-5-1f39e35bfe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35-fe57") == false); // invalid seperator
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35b") == false);     // too short
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-fe571f39e35bfe57") == false); // too long
-    assert(uuid_is_valid("a38fX5da-1456-498a-9ef5-1f39e35bfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-14x6-498a-9ef5-1f39e35bfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-1456-49za-9ef5-1f39e35bfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ey5-1f39e35bfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-1fq9e35bfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e3Sbfe57") == false); // invalid character
-    assert(uuid_is_valid("a38fa5da-l33t-498a-9ef5-1f39e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-8ef5-1f39e35bfe57"));
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35bfe57"));
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-aef5-1f39e35bfe57"));
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-bef5-1f39e35bfe57"));
+    ASSERT(uuid_is_valid("a38fa5da-1456-098a-9ef5-1f39e35bfe57") == false); // invalid type
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-0ef5-1f39e35bfe57") == false); // invalid subtype
+    ASSERT(uuid_is_valid("a38fa5da11456-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-14562498a-9ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a39ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef541f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38f-5da-1456-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-14-6-498a-9ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-49-a-9ef5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9e-5-1f39e35bfe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35-fe57") == false); // invalid seperator
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e35b") == false);     // too short
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-fe571f39e35bfe57") == false); // too long
+    ASSERT(uuid_is_valid("a38fX5da-1456-498a-9ef5-1f39e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-14x6-498a-9ef5-1f39e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-1456-49za-9ef5-1f39e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ey5-1f39e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-1fq9e35bfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-1456-498a-9ef5-1f39e3Sbfe57") == false); // invalid character
+    ASSERT(uuid_is_valid("a38fa5da-l33t-498a-9ef5-1f39e35bfe57") == false); // invalid character
 
     for (auto i = 0; i < 100000; ++i) {
         char buffer[37];
         uuid_random(buffer);
-        assert(uuid_is_valid(buffer));
+        ASSERT(uuid_is_valid(buffer));
     }
 }
 
@@ -121,10 +144,10 @@ int main ( int argc, char *argv[], char *envp[])
 {
     try {
         uuid_test();
+        return 0;
     }
     catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
-        return 3;
     }
-    return 0;
+    return 3;
 }

--- a/tools/external/driver-tool/SDL-response.cpp
+++ b/tools/external/driver-tool/SDL-response.cpp
@@ -155,7 +155,7 @@ struct Response2 : public ::Response2 {
         {}
 
         static std::string ordinalString(unsigned ordinal) {
-            return STD_STRING_LITERAL("# ") + std::to_string(ordinal);
+            return std::string("# ") + std::to_string(ordinal);
         }
         DecodingError setCause(std::string const &field) {
             this->field = field;
@@ -490,7 +490,8 @@ struct Response2 : public ::Response2 {
         };
 
         struct Delegate final : public JSONParser::Delegate {
-            JSONValueDelegate<std::string> query, status, message;
+            JSONValueDelegate<std::string> query, message;
+            JSONValueDelegate<std::string, JSONNumber> status;
             ArrayDelegate<FileEntry, Base::Files> files;
 
             bool wasSet = false;
@@ -551,7 +552,7 @@ struct Response2 : public ::Response2 {
 
                 return {
                       query.get()
-                    , status.rawValue()
+                    , status.get()
                     , message.get()
                     , files.get()
                 };
@@ -571,7 +572,8 @@ struct Response2 : public ::Response2 {
     };
 
     struct Delegate final : public JSONParser::Delegate {
-        JSONValueDelegate<std::string> version, status, message, nextToken;
+        JSONValueDelegate<std::string> version, message, nextToken;
+        JSONValueDelegate<std::string, JSONNumber> status;
         ArrayDelegate<ResultEntry, Base::Results> results;
 
         bool wasSet = false; ///< becomes true if we received at least one member event
@@ -637,7 +639,7 @@ struct Response2 : public ::Response2 {
                 };
             }
             return {
-                  status.rawValue()
+                  status.get()
                 , message ? message.get() : ""
             };
         }

--- a/tools/external/driver-tool/file-path.hpp
+++ b/tools/external/driver-tool/file-path.hpp
@@ -71,6 +71,7 @@ public:
 #if USE_WIDE_API
     operator std::wstring() const;
 #endif
+    NativeString const &rawValue() const { return path; }
 
     size_t size() const;
     bool empty() const { return path.empty(); }

--- a/tools/external/driver-tool/file-path.posix.cpp
+++ b/tools/external/driver-tool/file-path.posix.cpp
@@ -68,11 +68,6 @@ FilePath::operator std::string() const {
     return path;
 }
 
-NativeString FilePath::fileSystemRepresentation() const
-{
-    return path;
-}
-
 size_t FilePath::size() const {
     return trimPath(path).size();
 }

--- a/tools/external/driver-tool/file-path.posix.cpp
+++ b/tools/external/driver-tool/file-path.posix.cpp
@@ -68,6 +68,11 @@ FilePath::operator std::string() const {
     return path;
 }
 
+NativeString FilePath::fileSystemRepresentation() const
+{
+    return path;
+}
+
 size_t FilePath::size() const {
     return trimPath(path).size();
 }

--- a/tools/external/driver-tool/file-path.win32.cpp
+++ b/tools/external/driver-tool/file-path.win32.cpp
@@ -433,7 +433,7 @@ FilePath::operator std::string() const
 #if USE_WIDE_API
 FilePath::operator std::wstring() const
 {
-    return path.empty() ? path : std::wstring(canonicalPathPOSIX(path).get());
+    return path.empty() ? path : canonicalPath(path);
 }
 
 size_t FilePath::size() const
@@ -441,7 +441,6 @@ size_t FilePath::size() const
     auto const &asString = this->operator std::wstring();
     return asString.size();
 }
-#else
 #endif
 
 static NativeString trimPath(NativeString const &path, bool canTrim = true)

--- a/tools/external/driver-tool/file-path.win32.cpp
+++ b/tools/external/driver-tool/file-path.win32.cpp
@@ -438,7 +438,7 @@ NativeString FilePath::fileSystemRepresentation() const
 #if USE_WIDE_API
 FilePath::operator std::wstring() const
 {
-    return path.empty() ? path : canonicalPath(path);
+    return path.empty() ? path : std::wstring(canonicalPathPOSIX(path).get());
 }
 
 size_t FilePath::size() const
@@ -446,6 +446,7 @@ size_t FilePath::size() const
     auto const &asString = this->operator std::wstring();
     return asString.size();
 }
+#else
 #endif
 
 static NativeString trimPath(NativeString const &path, bool canTrim = true)

--- a/tools/external/driver-tool/file-path.win32.cpp
+++ b/tools/external/driver-tool/file-path.win32.cpp
@@ -421,7 +421,7 @@ static NativeString pathCombine(NativeString const &left, NativeString const &in
                         );
 }
 
-std::string getPathA(FilePath const &in) const
+std::string getPathA(FilePath const &in)
 {
     auto const &path = in.rawValue();
     if (path.empty())
@@ -433,7 +433,7 @@ std::string getPathA(FilePath const &in) const
     return std::string(cpath.get());
 }
 
-std::wstring getPathW(FilePath const &in) const
+std::wstring getPathW(FilePath const &in)
 {
     auto const &path = in.rawValue();
     if (path.empty())

--- a/tools/external/driver-tool/file-path.win32.cpp
+++ b/tools/external/driver-tool/file-path.win32.cpp
@@ -421,6 +421,29 @@ static NativeString pathCombine(NativeString const &left, NativeString const &in
                         );
 }
 
+std::string getPathA(FilePath const &in) const
+{
+    auto const &path = in.rawValue();
+    if (path.empty())
+        return std::string();
+
+    auto const wcpath = canonicalPathW(path);
+    auto const cpath = Win32Support::makeUnwide(wcpath.get());
+
+    return std::string(cpath.get());
+}
+
+std::wstring getPathW(FilePath const &in) const
+{
+    auto const &path = in.rawValue();
+    if (path.empty())
+        return std::wstring();
+
+    auto const wcpath = canonicalPathW(path);
+
+    return std::wstring(wcpath.get());
+}
+
 FilePath::operator std::string() const
 {
 #if USE_WIDE_API
@@ -428,11 +451,6 @@ FilePath::operator std::string() const
 #else
     return path.empty() ? std::string() : std::string(canonicalPathPOSIX(path).get());
 #endif
-}
-
-NativeString FilePath::fileSystemRepresentation() const
-{
-    return path.empty() ? path : canonicalPath(path);
 }
 
 #if USE_WIDE_API

--- a/tools/external/driver-tool/file-path.win32.cpp
+++ b/tools/external/driver-tool/file-path.win32.cpp
@@ -430,6 +430,11 @@ FilePath::operator std::string() const
 #endif
 }
 
+NativeString FilePath::fileSystemRepresentation() const
+{
+    return path.empty() ? path : canonicalPath(path);
+}
+
 #if USE_WIDE_API
 FilePath::operator std::wstring() const
 {
@@ -568,10 +573,10 @@ bool FilePath::removeSuffix(std::string const &in_suffix)
 
     if (path.size() < suffix.size())
         return false;
-    
+
     if (path.substr(path.size() - suffix.size()) != suffix)
         return false;
-        
+
     path.resize(path.size() - suffix.size());
     return true;
 }

--- a/tools/external/driver-tool/json-parse.hpp
+++ b/tools/external/driver-tool/json-parse.hpp
@@ -217,7 +217,7 @@ private:
     void send(enum EventType const type, char const *const start, char const *const end)
     {
         auto const delegate = delegates.back();
-        auto const nd = delegate->receive(type, StringView(start, end));
+        auto const nd = delegate->receive(type, StringView(start, end - start));
 
         if (nd == nullptr)
             delegates.pop_back();
@@ -335,7 +335,7 @@ struct JSONString {
     bool isMemberName;
 #endif
     explicit JSONString(StringView const &value, bool isMemberName = false)
-    : value(value.begin() + (isMemberName ? 0 : 1), value.end() - (isMemberName ? 0 : 1))
+    : value(value.begin() + (isMemberName ? 0 : 1), value.size() - (isMemberName ? 0 : 2))
 #if PEDANTIC_MEMBER_NAMES
     , isMemberName(isMemberName)
 #endif

--- a/tools/external/driver-tool/proc.win32.cpp
+++ b/tools/external/driver-tool/proc.win32.cpp
@@ -46,6 +46,9 @@
 #include "wide-char.hpp"
 #include "win32-cmdline.hpp"
 
+extern std::string getPathA(FilePath const &in) const;
+extern std::wstring getPathW(FilePath const &in) const;
+
 #if USE_WIDE_API
 
 static
@@ -67,7 +70,8 @@ DWORD runAndWait(FilePath const &toolpath, std::string const &toolname, wchar_t 
         si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
         si.dwFlags |= STARTF_USESTDHANDLES;
 
-        if (!CreateProcessW(std::wstring(toolpath).c_str(), (LPWSTR)wcmdline.get(), NULL, NULL, FALSE, CREATE_UNICODE_ENVIRONMENT, NULL, NULL, &si, &pi))
+        auto const path = getPathW(toolpath);
+        if (!CreateProcessW(path.c_str(), (LPWSTR)wcmdline.get(), NULL, NULL, TRUE, CREATE_UNICODE_ENVIRONMENT, NULL, NULL, &si, &pi))
         {
             throw_system_error("CreateProcess");
         }
@@ -81,8 +85,6 @@ DWORD runAndWait(FilePath const &toolpath, std::string const &toolname, wchar_t 
         ExitProcess(0);
     return 0;
 }
-
-#else
 
 #endif
 
@@ -104,7 +106,8 @@ DWORD runAndWait(FilePath const &toolpath, std::string const &toolname, char con
         si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
         si.dwFlags |= STARTF_USESTDHANDLES;
 
-        if (!CreateProcessA(std::string(toolpath).c_str(), (LPSTR)cmdline.get(), NULL, NULL, FALSE, CREATE_UNICODE_ENVIRONMENT, NULL, NULL, &si, &pi))
+        auto const path = getPathA(toolpath);
+        if (!CreateProcessA(path.c_str(), (LPSTR)cmdline.get(), NULL, NULL, TRUE, CREATE_UNICODE_ENVIRONMENT, NULL, NULL, &si, &pi))
         {
             throw_system_error("CreateProcess");
         }

--- a/tools/external/driver-tool/proc.win32.cpp
+++ b/tools/external/driver-tool/proc.win32.cpp
@@ -46,8 +46,8 @@
 #include "wide-char.hpp"
 #include "win32-cmdline.hpp"
 
-extern std::string getPathA(FilePath const &in) const;
-extern std::wstring getPathW(FilePath const &in) const;
+extern std::string getPathA(FilePath const &in);
+extern std::wstring getPathW(FilePath const &in);
 
 #if USE_WIDE_API
 

--- a/tools/external/driver-tool/tool-args.cpp
+++ b/tools/external/driver-tool/tool-args.cpp
@@ -68,16 +68,6 @@
 #include "fastq-dump-arguments.h"
 #include "tool-arguments.h"
 
-ParameterDefinition const &ParameterDefinition::unknownParameter() {
-    static auto const y = ParameterDefinition(TOOL_ARG(nullptr, nullptr, false, {}));
-    return y;
-}
-
-ParameterDefinition const &ParameterDefinition::argument() {
-    static auto const y = ParameterDefinition(TOOL_ARG(nullptr, nullptr, true, {}));
-    return y;
-}
-
 class JSON_Printer {
     std::ostream &out;
     int indent;

--- a/tools/external/driver-tool/tool-args.hpp
+++ b/tools/external/driver-tool/tool-args.hpp
@@ -55,11 +55,21 @@ struct ParameterDefinition {
     bool argumentIsOptional; ///< only fastq-dump has parameters with optional arguments, other tools do not.
 
     /// @brief The argument appears to be a parameter, but it is not in the list of known parameters for the tool. It does not take an argument.
-    static ParameterDefinition const &unknownParameter();
+    static ParameterDefinition const &unknownParameter() {
+        static constexpr ParameterDefinition const value { nullptr, nullptr, 0, false, false };
+        static_assert(value.hasArgument == false, "");
+        static_assert(value.name == nullptr, "");
+        return value;
+    }
 
     /// @brief The query is not a parameter for the tool, it is an argument.
-    static ParameterDefinition const &argument();
-
+    static ParameterDefinition const &argument() {
+        static constexpr ParameterDefinition const value { nullptr, nullptr, 0, true, false };
+        static_assert(value.hasArgument == true, "");
+        static_assert(value.name == nullptr, "");
+        return value;
+    }
+    
     /// @brief False for unknown parameters.
     operator bool() const {
         return !!name;

--- a/tools/external/driver-tool/util.hpp
+++ b/tools/external/driver-tool/util.hpp
@@ -99,7 +99,7 @@ struct StringView {
 private:
     char const *begin_;
     char const *end_;
-    
+
     size_type copy(char *dst) const {
         auto cur = dst;
         for (auto ch : *this)
@@ -116,7 +116,7 @@ private:
     }
 public:
     static const size_type npos = ~(size_type(0));
-    
+
     StringView()
     : begin_(nullptr)
     , end_(nullptr)
@@ -154,7 +154,7 @@ public:
     char const *end() const { return end_; }
     char const *cbegin() const { return begin_; }
     char const *cend() const { return end_; }
-    
+
     char const &operator [](size_type i) const {
         auto const ptr = begin_ + i;
         assert(ptr < end_);
@@ -198,7 +198,7 @@ public:
     StringView substr(size_type pos, size_type count) const {
         if (count == npos)
             return substr(pos);
-        
+
         if (pos < size()) {
             auto const ptr = begin_ + pos;
             return StringView(ptr, std::min(ptr + count, end_));
@@ -208,13 +208,13 @@ public:
     size_type copy(char *dst, size_type count, size_type pos = 0) {
         if (pos < size())
             return substr(pos, count).copy(dst);
-        
+
         throw std::out_of_range("StringView::copy: pos beyond end");
     }
     int compare(StringView const &rhs) const {
         auto const lsize = size();
         auto const rsize = rhs.size();
-        
+
         if (rsize < lsize)
             return -rhs.compare(*this);
 
@@ -266,7 +266,7 @@ public:
     bool ends_with(char const *other) const {
         return ends_with(StringView(other));
     }
-    
+
     operator std::string() const {
         return std::string(begin(), end());
     }
@@ -351,9 +351,9 @@ public:
     private:
         SmallArray *const parent;
         size_type current;
-        
+
         friend SmallArray;
-        
+
         Iterator(SmallArray *const par, size_type const cur = 0)
         : parent(par)
         , current(cur)
@@ -404,7 +404,7 @@ public:
         Iterator &operator+= (difference_type i) {
             if (i < 0)
                 return this -= -i;
-            
+
             if (parent->validIndex(current + i))
                 current += i;
             else
@@ -435,7 +435,7 @@ public:
     private:
         Iterator base_;
         friend SmallArray;
-        
+
         ConstIterator(Iterator const &other)
         : base_(other)
         {}
@@ -554,7 +554,7 @@ ITER lowerBound(ITER const &beg, ITER const &end, VALUE const &value, COMP comp)
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (comp(*m, value))
@@ -570,7 +570,7 @@ ITER lowerBound(ITER const &beg, ITER const &end, VALUE const &value)
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (*m < value)
@@ -586,7 +586,7 @@ ITER upperBound(ITER const &beg, ITER const &end, VALUE const &value, COMP comp)
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (!comp(value, *m))
@@ -602,7 +602,7 @@ ITER upperBound(ITER const &beg, ITER const &end, VALUE const &value)
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (!(value < *m))
@@ -618,7 +618,7 @@ std::pair<ITER, ITER> equalRange(ITER const &beg, ITER const &end, VALUE const &
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (less(*m, value))
@@ -636,7 +636,7 @@ std::pair<ITER, ITER> equalRange(ITER const &beg, ITER const &end, VALUE const &
 {
     auto f = beg;
     auto e = end;
-    
+
     while (f < e) {
         auto const m = middle(f, e);
         if (*m < value)
@@ -717,10 +717,9 @@ public:
     {
         if (container.empty()) {
     AT_BACK:
-            auto const at = (decltype(std::distance(container.begin(), container.end())))(container.size());
-            auto result = container.begin();
             container.emplace_back(value);
-            std::advance(result, at);
+            auto result = (container.rbegin() + 1).base();
+            assert(&*result == &container.back());
             return result;
         }
 
@@ -735,7 +734,7 @@ public:
         auto const at = std::distance(container.begin(), before);
         if (UNIQUE && at > 0 && container[at - 1] == value)
             goto NOT_UNIQUE;
-        
+
         container.insert(before, value);
         {
             auto result = container.begin();

--- a/tools/external/driver-tool/util.posix.hpp
+++ b/tools/external/driver-tool/util.posix.hpp
@@ -44,7 +44,8 @@ static inline std::error_code error_code_from_errno()
 namespace POSIX {
 struct EnvironmentVariables {
     static opt_string get(char const *name) {
-        return opt_string(getenv(name));
+        auto const val = getenv(name);
+        return val ? opt_string(val) : opt_string();
     }
     static void set(char const *name, char const *value) {
         if (value)


### PR DESCRIPTION
This should fix the windows problem.

This is based on the branch with the fixes to the tests, so it has those too. But the focus of this branch are the changes to 
file-path.hpp
file-path.win32.cpp
proc.win32.cpp

The file-path.* changes are to get the path string (in the needed encoding) to proc.win32.cpp.