### PR TITLE
build: add missing include

### DIFF
--- a/tools/external/driver-tool/file-path.posix.cpp
+++ b/tools/external/driver-tool/file-path.posix.cpp
@@ -43,6 +43,7 @@
 #include "file-path.hpp"
 #include <algorithm>
 #include <vector>
+#include <cstring>
 #include <string>
 
 FilePath::FilePath(NativeString const &in) : path(in) {}


### PR DESCRIPTION
Adding missing `<cstring>`

The error build log:

```
/tmp/sratoolkit-20230107-88915-14o3z48/sra-tools-3.0.3/tools/external/driver-tool/file-path.posix.cpp:151:13: error: 'strncmp' was not declared in this scope
  151 |         if (strncmp(*cur, "executable_path=", 16) == 0) { // usually
      |             ^~~~~~~
/tmp/sratoolkit-20230107-88915-14o3z48/sra-tools-3.0.3/tools/external/driver-tool/file-path.posix.cpp:44:1: note: 'strncmp' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
   43 | #include "file-path.hpp"
  +++ |+#include <cstring>
   44 | #include <algorithm>
```

relates to https://github.com/Homebrew/homebrew-core/pull/119916