### PR TITLE
ngs-java: locate the ngs directory directly in TARGDIR

### DIFF
--- a/ngs/ngs-java/CMakeLists.txt
+++ b/ngs/ngs-java/CMakeLists.txt
@@ -140,17 +140,12 @@ if ( Java_FOUND )
             set(SRC_FILES "${SRC_FILES} ${f}")
         endforeach()
 
-        if( ${OS} STREQUAL "windows" )
-            set( NGS_JAVADOC_DIR ${TARGDIR} )
-        else()
-            set( NGS_JAVADOC_DIR ${TARGDIR}/obj )
-        endif()
         if ( Java_JAR_EXECUTABLE AND NOT (${OS} STREQUAL "windows") )
             add_custom_target(
                 ngs-doc-jar ALL COMMAND
                 bash -c "${Java_JAR_EXECUTABLE} -cf ${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar ."
                 DEPENDS ngs-doc_javadoc
-                WORKING_DIRECTORY "${NGS_JAVADOC_DIR}/ngs/ngs-java/javadoc/ngs-doc"
+                WORKING_DIRECTORY "${TARGDIR}/ngs/ngs-java/javadoc/ngs-doc"
             )
             install( FILES ${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar DESTINATION ${CMAKE_INSTALL_PREFIX}/jar/ )
 
@@ -166,7 +161,7 @@ if ( Java_FOUND )
                 ngs-doc-jar ALL COMMAND
                 "${Java_JAR_EXECUTABLE}" -cf "${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar" .
                 DEPENDS ngs-doc_javadoc
-                WORKING_DIRECTORY "${NGS_JAVADOC_DIR}/ngs/ngs-java/javadoc/ngs-doc"
+                WORKING_DIRECTORY "${TARGDIR}/ngs/ngs-java/javadoc/ngs-doc"
             )
             install( FILES ${CMAKE_JAR_OUTPUT_DIRECTORY}/ngs-doc.jar DESTINATION ${CMAKE_INSTALL_PREFIX}/jar/ )
 


### PR DESCRIPTION
Fixes #771 

I'm not sure where is the origin of the extra `obj` directory in this target path. But at least on our Linux systems, the `ngs` folder is found inside `TARGDIR`.