### PR TITLE
VDB-5546

### DIFF
--- a/tools/external/vdb-validate/main.c
+++ b/tools/external/vdb-validate/main.c
@@ -149,6 +149,10 @@ static const char *USAGE_IND_ONLY[] =
 static const char *USAGE_CHECK_REDACT[] =
 { "check if redaction of bases has been correctly performed (default: false)", NULL };
 
+#define OPTION_REQUIRE_BLOB_CRC "require-blob-checksums"
+static const char *const USAGE_REQUIRE_BLOB_CRC[] = 
+{ "Require blob checksums (default: no)", NULL };
+
 static OptDef options [] =
 {                                                    /* needs_value, required */
 /*  { OPTION_MD5     , ALIAS_MD5     , NULL, USAGE_MD5     , 1, true , false }*/
@@ -177,6 +181,8 @@ static OptDef options [] =
   , { OPTION_ref_int , ALIAS_ref_int , NULL, USAGE_REF_INT , 1, false, false }
 
   , { OPTION_CHECK_REDACT, NULL      , NULL, USAGE_CHECK_REDACT, 1, false , false }
+
+  , { OPTION_REQUIRE_BLOB_CRC, NULL  , NULL, USAGE_REQUIRE_BLOB_CRC, 1, false , false }
 };
 
 /*
@@ -227,6 +233,8 @@ rc_t CC Usage ( const Args * args )
     HelpOptionLine(NULL          , OPTION_NGC           , "path", USAGE_NGC);
 
     HelpOptionLine(NULL          , OPTION_CHECK_REDACT, NULL, USAGE_CHECK_REDACT);
+
+    HelpOptionLine(NULL          , OPTION_REQUIRE_BLOB_CRC, NULL, USAGE_REQUIRE_BLOB_CRC);
 /*
 #define NUM_LISTABLE_OPTIONS \
     ( sizeof options / sizeof options [ 0 ] - NUM_SILENT_TRAILING_OPTIONS )
@@ -296,6 +304,12 @@ rc_t parse_args ( vdb_validate_params *pb, Args *args )
       if ( rc != 0 )
           return rc;
       pb -> check_redact = ( cnt != 0 );
+  }
+  {
+      rc = ArgsOptionCount ( args, OPTION_REQUIRE_BLOB_CRC, & cnt );
+      if ( rc != 0 )
+          return rc;
+      pb -> blob_crc_required = ( cnt != 0 );
   }
   
   {
@@ -431,58 +445,58 @@ rc_t parse_args ( vdb_validate_params *pb, Args *args )
       }
   }
   {
-        rc = ArgsOptionCount ( args, OPTION_SDC_SEQ_ROWS, &cnt );
+    rc = ArgsOptionCount ( args, OPTION_SDC_SEQ_ROWS, &cnt );
+    if (rc)
+    {
+        LOGERR (klogInt, rc, "ArgsOptionCount() failed for " OPTION_SDC_SEQ_ROWS);
+        return rc;
+    }
+
+    if (cnt > 0)
+    {
+        uint64_t value;
+        size_t value_size;
+        rc = ArgsOptionValue ( args, OPTION_SDC_SEQ_ROWS, 0, (const void **) &dummy );
         if (rc)
         {
-            LOGERR (klogInt, rc, "ArgsOptionCount() failed for " OPTION_SDC_SEQ_ROWS);
+            LOGERR (klogInt, rc, "ArgsOptionValue() failed for " OPTION_SDC_SEQ_ROWS);
             return rc;
         }
 
-        if (cnt > 0)
+        pb->sdc_enabled = true;
+
+        value_size = string_size ( dummy );
+        if ( value_size >= 1 && dummy[value_size - 1] == '%' )
         {
-            uint64_t value;
-            size_t value_size;
-            rc = ArgsOptionValue ( args, OPTION_SDC_SEQ_ROWS, 0, (const void **) &dummy );
+            value = string_to_U64 ( dummy, value_size - 1, &rc );
             if (rc)
             {
-                LOGERR (klogInt, rc, "ArgsOptionValue() failed for " OPTION_SDC_SEQ_ROWS);
+                LOGERR (klogInt, rc, "string_to_U64() failed for " OPTION_SDC_SEQ_ROWS);
+                return rc;
+            }
+            else if (value == 0 || value > 100)
+            {
+                rc = RC(rcExe, rcArgv, rcParsing, rcParam, rcInvalid);
+                LOGERR (klogInt, rc, OPTION_SDC_SEQ_ROWS " has illegal percentage value (has to be 1-100%)" );
                 return rc;
             }
 
-            pb->sdc_enabled = true;
-
-            value_size = string_size ( dummy );
-            if ( value_size >= 1 && dummy[value_size - 1] == '%' )
+            pb->sdc_seq_rows_in_percent = true;
+            pb->sdc_seq_rows.percent = (double)value / 100;
+        }
+        else
+        {
+            value = string_to_U64 ( dummy, value_size, &rc );
+            if (rc)
             {
-                value = string_to_U64 ( dummy, value_size - 1, &rc );
-                if (rc)
-                {
-                    LOGERR (klogInt, rc, "string_to_U64() failed for " OPTION_SDC_SEQ_ROWS);
-                    return rc;
-                }
-                else if (value == 0 || value > 100)
-                {
-                    rc = RC(rcExe, rcArgv, rcParsing, rcParam, rcInvalid);
-                    LOGERR (klogInt, rc, OPTION_SDC_SEQ_ROWS " has illegal percentage value (has to be 1-100%)" );
-                    return rc;
-                }
-
-                pb->sdc_seq_rows_in_percent = true;
-                pb->sdc_seq_rows.percent = (double)value / 100;
+                LOGERR (klogInt, rc, "string_to_U64() failed for " OPTION_SDC_SEQ_ROWS);
+                return rc;
             }
-            else
-            {
-                value = string_to_U64 ( dummy, value_size, &rc );
-                if (rc)
-                {
-                    LOGERR (klogInt, rc, "string_to_U64() failed for " OPTION_SDC_SEQ_ROWS);
-                    return rc;
-                }
-                pb->sdc_seq_rows_in_percent = false;
-                pb->sdc_seq_rows.number = value;
-            }
+            pb->sdc_seq_rows_in_percent = false;
+            pb->sdc_seq_rows.number = value;
         }
     }
+  }
     {
         rc = ArgsOptionCount ( args, OPTION_SDC_PLEN_THOLD, &cnt );
         if (rc)

--- a/tools/external/vdb-validate/vdb-validate.c
+++ b/tools/external/vdb-validate/vdb-validate.c
@@ -421,7 +421,7 @@ rc_t kdbcc ( const KDBManager *mgr, char const name[], uint32_t mode,
         if (blob_crc_required)
             rc = RC ( rcExe, *pathType == kptDatabase ? rcDatabase : rcTable, rcValidating, rcChecksum, rcNotFound );
         else
-            (void)LOGMSG(klogInfo, "checksums missing");
+            (void)LOGMSG(klogWarn, "checksums missing");
     }
         
     if (rc == 0 && ctx.num_columns == 0 && !s_IndexOnly)

--- a/tools/external/vdb-validate/vdb-validate.c
+++ b/tools/external/vdb-validate/vdb-validate.c
@@ -113,6 +113,7 @@ typedef struct node_s {
     unsigned name;
     uint32_t objType;
 } node_t;
+
 typedef struct cc_context_s {
     node_t *nodes;
     char *names;
@@ -120,7 +121,9 @@ typedef struct cc_context_s {
     unsigned num_columns;
     unsigned nextNode;
     unsigned nextName;
+    unsigned missingChecksum;
 } cc_context_t;
+
 static
 rc_t report_rtn ( rc_t rc )
 {
@@ -174,6 +177,9 @@ static rc_t report_column(CCReportInfoBlock const *what, cc_context_t *ctx)
         }
         return report_rtn (what->info.done.rc);
     case ccrpt_Blob:
+        if (what->info.blob.missingChecksum) {
+            ctx->missingChecksum += 1;
+        }
         return 0; /* continue with check */
     case ccrpt_MD5:
         if (what->info.MD5.rc) {
@@ -349,15 +355,15 @@ rc_t kdbcc ( const KDBManager *mgr, char const name[], uint32_t mode,
     rc_t rc = 0;
     cc_context_t ctx;
     char const *objtype;
-
+    bool const blob_crc_required = (mode & 8) != 0;
     uint32_t level = ( mode & 4 ) ? 3 : ( mode & 2 ) ? 1 : 0;
-    if (s_IndexOnly)
-        level |= CC_INDEX_ONLY;
-
 
     memset(&ctx, 0, sizeof(ctx));
     ctx.nodes = &nodes[0];
     ctx.names = &names[0];
+
+    if (s_IndexOnly)
+        level |= CC_INDEX_ONLY;
 
     if (KDBManagerExists(mgr, kptDatabase, "%s", name))
         *pathType = kptDatabase;
@@ -411,6 +417,13 @@ rc_t kdbcc ( const KDBManager *mgr, char const name[], uint32_t mode,
         }
     }
 
+    if (rc == 0 && ctx.missingChecksum > 0) {
+        if (blob_crc_required)
+            rc = RC ( rcExe, *pathType == kptDatabase ? rcDatabase : rcTable, rcValidating, rcChecksum, rcNotFound );
+        else
+            (void)LOGMSG(klogInfo, "checksums missing");
+    }
+        
     if (rc == 0 && ctx.num_columns == 0 && !s_IndexOnly)
     {
         if (is_file)
@@ -2410,6 +2423,7 @@ rc_t dbcc ( const vdb_validate_params *pb, const char *path, bool is_file )
         uint32_t mode = ( pb -> md5_chk ? 1 : 0 )
                       | ( pb -> blob_crc ? 2 : 0 )
                       | ( pb -> index_chk ? 4 : 0 )
+                      | ( pb -> blob_crc_required ? 8 : 0 )
                       ;
         /* check as kdb object */
         if ( rc == 0 )

--- a/tools/external/vdb-validate/vdb-validate.h
+++ b/tools/external/vdb-validate/vdb-validate.h
@@ -47,6 +47,7 @@ struct vdb_validate_params
     bool consist_check;
     bool exhaustive;
     bool check_redact;
+    bool blob_crc_required;
 
     // data integrity checks parameters
     bool sdc_enabled;


### PR DESCRIPTION
`vdb-validate` can respond to missing blob checksums, and optionally, can exit with a message and error code.