### PR TITLE
VDB-5762

### DIFF
--- a/libs/inc/vdb.hpp
+++ b/libs/inc/vdb.hpp
@@ -60,11 +60,22 @@ namespace VDB {
     class Error : public std::exception {
         rc_t rc;
         std::string text;
+        char const *file;
+        int line;
 
     public:
-        Error(rc_t const rc_, char const *file, int line) : rc(rc_) {
-            std::cerr << "RC " << rc << " thrown by " << file << ':' << line << std::endl;
+        bool handled;
 
+        ~Error() {
+            if (!handled)
+                std::cerr << "RC " << rc << " thrown by " << file << ':' << line << std::endl;
+        }
+        Error(rc_t const rc_, char const *file_, int line_)
+        : rc(rc_) 
+        , file(file_)
+        , line(line_)
+        , handled(false)
+        {
             std::stringstream out;
             out << file << ":" << line << ": ";
             if ( rc != 0 )
@@ -73,19 +84,26 @@ namespace VDB {
             }
             text = out.str();
         }
-        Error(const char * msg, char const *file, int line) : rc(0) {
+        Error(const char * msg, char const *file_, int line_) 
+        : rc(0)
+        , file(file_)
+        , line(line_)
+        , handled(true)
+        {
             std::cerr << "'" << msg << "' thrown by " << file << ':' << line << std::endl;
 
             std::stringstream out;
             out << file << ":" << line << ": " << msg;
             text = out.str();
         }
-        Error(const std::string & msg) : rc(0) {
+        Error(const std::string & msg) 
+        : rc(0)
+        , file(nullptr)
+        , line(0)
+        , text(msg)
+        , handled(true)
+        {
             std::cerr << msg << std::endl;
-
-            std::stringstream out;
-            out << msg;
-            text = out.str();
         }
 
         char const *what() const throw()

--- a/libs/inc/vdb.hpp
+++ b/libs/inc/vdb.hpp
@@ -98,9 +98,9 @@ namespace VDB {
         }
         Error(const std::string & msg) 
         : rc(0)
+        , text(msg)
         , file(nullptr)
         , line(0)
-        , text(msg)
         , handled(true)
         {
             std::cerr << msg << std::endl;

--- a/test/external/prefetch/urls_and_accs.pl
+++ b/test/external/prefetch/urls_and_accs.pl
@@ -193,7 +193,7 @@ $REFSEQF = "$SRAF:data/sracloud/traces/refseq/$REFSEQC";
 
 print "prefetch $REFSEQ when there is no kfg\n";
 `rm -f $REFSEQC`; die if $?;
-$CMD = "NCBI_SETTINGS=/ VDB_CONFIG=$CWD/tmp $DIRTOTEST/$PREFETCH $REFSEQ";
+$CMD = "NCBI_SETTINGS=/ NCBI_VDB_RELIABLE=1 VDB_CONFIG=$CWD/tmp $DIRTOTEST/$PREFETCH $REFSEQ";
 print "$CMD\n" if $VERBOSE;
 `$CMD`; die if $?;
 `rm $REFSEQC`; die if $?;

--- a/tools/external/sra-info/sra-info.cpp
+++ b/tools/external/sra-info/sra-info.cpp
@@ -81,9 +81,10 @@ SraInfo::SetAccession( const std::string& p_accession )
             m_u.tbl = new VDB::Table { m_mgr.openTable(m_accession) };
             return;
         }
-        catch (VDB::Error const &err) {
+        catch (VDB::Error &err) {
             if ((int)err.getRc() != 1434782232) // if not "schema not found while opening table within virtual database module"
                 throw;
+            err.handled = true;
         }
         // fall through
     case VDB::Manager::ptPrereleaseTable :
@@ -163,7 +164,7 @@ SraInfo::GetPlatforms() const
             cursor.foreach( get_platform );
         }
     }
-    catch(const VDB::Error & e)
+    catch(VDB::Error & e)
     {
         rc_t rc = e.getRc();
         if ( rc != 0 )
@@ -171,6 +172,7 @@ SraInfo::GetPlatforms() const
             if ( GetRCObject( rc ) == (enum RCObject)rcColumn && GetRCState( rc ) == rcUndefined )
             {
                 ret.insert( PlatformToString( SRA_PLATFORM_UNDEFINED ) );
+                e.handled = true;
                 return ret;
             }
         }
@@ -453,7 +455,7 @@ static bool isLiteMetadata(VDB::MetadataCollection const &meta) {
     try {
         return meta.childNode("SOFTWARE/delite").attributeValue("name") == "delite";
     }
-    catch (VDB::Error const &rc) { ((void)(rc)); }
+    catch (VDB::Error &rc) { rc.handled = true; }
     return false;
 }
 


### PR DESCRIPTION
Defer to the destructor the printing of error message to stderr, print only if not `handled`.